### PR TITLE
Add de/ch/at boundaries for GoogleMaps

### DIFF
--- a/src/form/VcaLocation.vue
+++ b/src/form/VcaLocation.vue
@@ -84,7 +84,16 @@ export default {
         },
         autocompleteCallback() {
             // Load autocomplete from google places
-            const options = { types: [this.locationType] };
+            const options = {
+              types: [this.locationType],
+              // add bounds around Germany, Austria & Switzerland
+              bounds: {
+                north: 54.970804848009955, // South denmark
+                south: 45.59946845833749, // North italy
+                west: 5.764796691201656, // West of Genf
+                east: 17.3052751460145 // Bratislava
+              }
+            };
             if (this.lang) {
                 console.log("setting lang " + this.lang);
                 options["language"] = this.lang;


### PR DESCRIPTION
GoogleMaps is providing a lot of US locations by default. This PR draws a bounding box to prefer locations in Germany, Austria and Switzerland. Other locations are also shown, but with lower precedence.

Selected box is:
http://bboxfinder.com/#45.59946845833749,5.764796691201656,54.970804848009955,17.3052751460145

Concrete examples:

Pier 2 (a concert location in Bremen)
Old version:
![grafik](https://github.com/Viva-con-Agua/vca-ui/assets/5451330/db5e15f8-4f5e-4279-a0f8-08ec9daf9097)

New:
![grafik](https://github.com/Viva-con-Agua/vca-ui/assets/5451330/ea205dee-2019-4dad-96b0-4bdd3010ca89)
(First result is the correct location)
