### PR TITLE
Set monday_first for vca-date

### DIFF
--- a/src/form/VcaDate.vue
+++ b/src/form/VcaDate.vue
@@ -63,7 +63,7 @@ export default {
             default: "de",
             validator: function (value) {
                 // The value must match one of these strings
-                return ["de", "en"].indexOf(value) !== -1;
+                return ["de", "ch", "en", "gb"].indexOf(value) !== -1;
             },
         },
         rules: {
@@ -95,7 +95,9 @@ export default {
             hasError: null,
             languages: {
                 de: de,
+                ch: de,
                 en: en,
+                gb: en
             },
         };
     },
@@ -111,7 +113,7 @@ export default {
             return new Date(this.value);
         },
         isMondayFirst: function() {
-          return this.$props.language === "de";
+          return this.$props.language === "de" || this.$props.language === "ch";
         }
     },
     created() {

--- a/src/form/VcaDate.vue
+++ b/src/form/VcaDate.vue
@@ -15,6 +15,7 @@
             :format="format"
             :language="languages[language]"
             :typeable="typeable"
+            :monday-first="isMondayFirst"
             :open-date="defaultValue"
             :disabled-dates="disabledVals"
             v-model="inputValue"
@@ -109,6 +110,9 @@ export default {
         getValue() {
             return new Date(this.value);
         },
+        isMondayFirst: function() {
+          return this.$props.language === "de";
+        }
     },
     created() {
         this.checkWrap();


### PR DESCRIPTION
Sets the basis for https://github.com/Viva-con-Agua/pool-webapp/issues/271. If this is merged, the issue 271 can be closed as resolved.

This sets the attribute monday-first, depending on the language which is selected. This requires to transfer the language to the field, e.g. by

```
 <vca-input-date
          ...
          :language="this.$i18n.locale"
```
