### PR TITLE
Reduce size of share icon

### DIFF
--- a/src/elements/VcaShareIcon.vue
+++ b/src/elements/VcaShareIcon.vue
@@ -42,8 +42,8 @@ export default {
 
     .mobile {
         display: inline-flex;
-        width: 35px;
-        height: 35px;
+        width: 32px;
+        height: 32px;
         margin: 0 10px;
         border-radius: 50%;
         border: solid 2px #008fc3;


### PR DESCRIPTION
To avoid problems with .event-title img in pool-webapp/App.vue, which reduces the height, but not the width to 32px.

see also
https://github.com/Viva-con-Agua/pool-webapp/blob/44a3f451f3df827f6923e123202bfd951403f472/src/App.vue#L446-L449

Old:
![grafik](https://github.com/Viva-con-Agua/vca-ui/assets/5451330/5e6edaa4-b260-44b2-9ce2-ddc2e4772c4b)

New:
![grafik](https://github.com/Viva-con-Agua/vca-ui/assets/5451330/6461575d-3e1e-42e1-8db6-5c91cc031884)
