### PR TITLE
Make links also white in tables row hover

### DIFF
--- a/src/assets/styles/table/_table.scss
+++ b/src/assets/styles/table/_table.scss
@@ -179,6 +179,10 @@
                 transition: 0.3s;
                 background-color: $primary-dark;
                 color: white;
+
+                a {
+                    color: white;
+                }
             }
         }
 


### PR DESCRIPTION
Fix links not being white in hover

Previously:
![grafik](https://github.com/user-attachments/assets/2e210aa1-29e1-4160-8e5c-262d1a5ebc8c)

Now:
![grafik](https://github.com/user-attachments/assets/965f1f9e-9ec4-450e-8f86-ee3168143643)
